### PR TITLE
Handle RFC 2822 dates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = "0.12.12"
 reqwest-middleware = "0.4.0"
 tokio = { version = "1.35.1", features = ["sync"] }
 task-local-extensions = "0.1.4"
+time = { version = "0.3.37", features = ["parsing"] }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["rt", "macros"] }


### PR DESCRIPTION
Integral seconds is only [one of two valid formats](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) of the `R-A` value.