### PR TITLE
Test RFC 2822 dates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ reqwest = "0.12.12"
 reqwest-middleware = "0.4.0"
 tokio = { version = "1.35.1", features = ["sync"] }
 task-local-extensions = "0.1.4"
-time = { version = "0.3.37", features = ["parsing"] }
+time = { version = "0.3.37", features = ["formatting", "parsing"] }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["rt", "macros"] }


### PR DESCRIPTION
By [request](https://github.com/melotic/reqwest-retry-after/pull/22#issuecomment-2571355585).

Also, refactor is-valid helper to use `Duration`s consistently.

It's probably safe to release `0.2.0` after this.